### PR TITLE
SIDASH-23: Charts should match size of widget on window resize

### DIFF
--- a/app/components/bar-chart.js
+++ b/app/components/bar-chart.js
@@ -16,6 +16,15 @@ export default Ember.Component.extend({
     sizeChanged: Ember.observer('resizedSignal', function() {
         this.updateBar();
     }),
+    
+    // Observe the width of the outer div (placeholder) surrounding the chart when browser size changes
+    parentWidthChanged: Ember.observer('parentWidth',function() {
+        if(this.get('parentWidth') < this.get('width')*150) { // If the outer div is narrower than the chart width
+            let w = this.get('parentWidth')/150; // Scale the outer div's size in units of 150 (to be consistent with our previous chart sizing)
+            this.set('width',w); // Set the "width" of the chart to this scaled unit
+            this.updateTS(); // Re-draw the chart at a smaller width
+        }
+    }),
 
     updateBar() {
         this.set('data', this.get('aggregations.contributors.buckets'));

--- a/app/components/bar-chart.js
+++ b/app/components/bar-chart.js
@@ -22,7 +22,7 @@ export default Ember.Component.extend({
         if(this.get('parentWidth') < this.get('width')*150) { // If the outer div is narrower than the chart width
             let w = this.get('parentWidth')/150; // Scale the outer div's size in units of 150 (to be consistent with our previous chart sizing)
             this.set('width',w); // Set the "width" of the chart to this scaled unit
-            this.updateTS(); // Re-draw the chart at a smaller width
+            this.updateBar(); // Re-draw the chart at a smaller width
         }
     }),
 

--- a/app/components/donut-chart.js
+++ b/app/components/donut-chart.js
@@ -17,6 +17,15 @@ export default Ember.Component.extend({
     sizeChanged: Ember.observer('resizedSignal', function() {
         this.updateDonut();
     }),
+    
+    // Observe the width of the outer div (placeholder) surrounding the chart when browser size changes
+    parentWidthChanged: Ember.observer('parentWidth',function() {
+        if(this.get('parentWidth') < this.get('width')*150) { // If the outer div is narrower than the chart width
+            let w = this.get('parentWidth')/150; // Scale the outer div's size in units of 150 (to be consistent with our previous chart sizing)
+            this.set('width',w); // Set the "width" of the chart to this scaled unit
+            this.updateTS(); // Re-draw the chart at a smaller width
+        }
+    }),
 
     updateDonut() {
         this.set('data', this.get('aggregations.sources.buckets'));

--- a/app/components/donut-chart.js
+++ b/app/components/donut-chart.js
@@ -23,7 +23,7 @@ export default Ember.Component.extend({
         if(this.get('parentWidth') < this.get('width')*150) { // If the outer div is narrower than the chart width
             let w = this.get('parentWidth')/150; // Scale the outer div's size in units of 150 (to be consistent with our previous chart sizing)
             this.set('width',w); // Set the "width" of the chart to this scaled unit
-            this.updateTS(); // Re-draw the chart at a smaller width
+            this.updateDonut(); // Re-draw the chart at a smaller width
         }
     }),
 

--- a/app/components/place-holder.js
+++ b/app/components/place-holder.js
@@ -20,6 +20,10 @@ export default Ember.Component.extend({
     computedWidth: 200,
 
     resizedSignal: false,
+    
+    resizingChanged: Ember.observer('resizing', function() {
+        this.set('computedHeight', this.$().width());
+    }),
 
     // Initialize our query parameters
     q: 'UC Santa Barbara',
@@ -155,8 +159,8 @@ export default Ember.Component.extend({
             this.sendAction('refreshWall');
             this.set('resizedSignal', true);
             this.set('configuring', !this.get('configuring'));
-        },
-
+        }
+        
     },
 
 });

--- a/app/components/timeseries-chart.js
+++ b/app/components/timeseries-chart.js
@@ -29,6 +29,15 @@ export default Ember.Component.extend({
         this.updateTS();
     }),
 
+    // Observe the width of the outer div (placeholder) surrounding the chart when browser size changes
+    parentWidthChanged: Ember.observer('parentWidth',function() {
+        if(this.get('parentWidth') < this.get('width')*150) { // If the outer div is narrower than the chart width
+            let w = this.get('parentWidth')/150; // Scale the outer div's size in units of 150 (to be consistent with our previous chart sizing)
+            this.set('width',w); // Set the "width" of the chart to this scaled unit
+            this.updateTS(); // Re-draw the chart at a smaller width
+        }
+    }),
+    
     updateTS() { // Update our TS chart when data/subsets change
         this.set('data', this.get('aggregations.articles_over_time.buckets'));
         let columns = this.get('timeseriesList');

--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -23,13 +23,15 @@ export default Ember.Controller.extend({
     // Initialize the three interchangeable charts to be rendered as sortableObjects
     sortableObjectList: [{isPlaceholder: true}],
 
-    
     // Initialize the list of additional charts that the user can add
     addableList: [],
 
     wall: false,
 
     storedDashboards: [],
+    
+    // An attribute used to track when the browser is resized and pass this event down to each placeholder component
+    resizing: false,
 
     actions: {
 

--- a/app/routes/dashboard.js
+++ b/app/routes/dashboard.js
@@ -19,6 +19,7 @@ export default Ember.Route.extend({
                 fixSize: 0,
                 cacheSize: true,
                 onResize: function() {
+                    controller.toggleProperty('resizing'); // Toggle this property to wake up the observer in place-holder.js
                     wall.refresh();
                 },
                 onBlockMove: function() {

--- a/app/templates/components/place-holder.hbs
+++ b/app/templates/components/place-holder.hbs
@@ -13,6 +13,6 @@
     </form>
 </div>
 
-{{component widgetType aggregations=aggregations width=widthSetting height=heightSetting interval=tsInterval resizedSignal=resizedSignal}}
+{{component widgetType aggregations=aggregations width=widthSetting height=heightSetting parentWidth=computedWidth interval=tsInterval resizedSignal=resizedSignal}}
 
 {{yield}}

--- a/app/templates/dashboard.hbs
+++ b/app/templates/dashboard.hbs
@@ -38,7 +38,7 @@
 </div>
 <div id='freewall' class='free-wall'>
         {{#each sortableObjectList as |item|}}
-            {{place-holder options=addableList addChart=(action "addChart") removeChart=(action 'removeChart') item=item wall=wall refreshWall=(action 'refreshWall')}}
+            {{place-holder options=addableList addChart=(action "addChart") removeChart=(action 'removeChart') item=item wall=wall resizing=resizing refreshWall=(action 'refreshWall')}}
         {{/each}}
 </div>
 


### PR DESCRIPTION
New code added:
dashboard.js (route):
	-in onResize hook: toggle the controller ‘resizing’ property
	-Pass the controller ‘resizing' property down to the placeholder chart
place-holder.js:
	-Set observer on the resizing property, ‘resizingChanged'
	-The observer is triggered whenever the property is toggled, i.e. any time the browser resizes
	-get the width of the placeholder div every time the observer is triggered
	-if the placeholder width is less than the chart with:
	-scale the placeholder width as a multiple of 150, to stay consistent with prior chart sizing methods
	-pass this down to the chart as parentWidth
XXX-chart.js:
	-Set an observer on the parent div's width (passed down). Update the chart to use the new width

Issues I've run into with this:
1. I sometimes get a weird deprecation warning that doesn’t seem to be documented in Ember.
2. Theortically, I don't want to be passing the ‘resizing’ and ‘parentWidth’ properties down and observing when they change. I'd prefer to just get() the new computedWidth when the browser resizes (i.e. when the didRender() hook in the place-holder.js file fires on resize). HOWEVER, for some reason there seems to be a delay in the updating of the computedWidth: if you resize the browser and thus the chart, then get the computedWidth, it shows the same width as before the resize. If, however, you do something (other than changing browser size) that makes didRender() run again after this and get the computedWidth again, it shows the correct, "new" width. I couldn't figure out why this was.
3. It sometimes seems like there is a significant "lag" between browser/outer div resize and chart resize 