### PR TITLE
transitions work from list widgets

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -1,0 +1,50 @@
+# See http://help.github.com/ignore-files/ for more about ignoring files.
+
+# compiled output
+dist/
+tmp/
+
+# dependencies
+node_modules/
+bower_components/
+
+# misc
+/.sass-cache
+/connect.lock
+/coverage/*
+/libpeerconnection.log
+npm-debug.log
+
+
+testem.log
+
+
+
+
+!.gitkeep
+# DB / Migrations
+# Python
+**/bower_components
+*.diff
+*.idea/
+*.py[cod]
+*.pyc
+*.so
+*/__pycache__/*
+.DS_Store
+.csv
+.env
+.idea
+.idea/
+.local_settings.pyc
+db.sqlite3
+env/
+static
+latest.dump
+local_settings.py
+local.py
+local.yml
+log
+media
+**/local.py
+~Envs/

--- a/client/.travis.yml
+++ b/client/.travis.yml
@@ -1,0 +1,24 @@
+---
+language: node_js
+node_js:
+  - "4"
+
+sudo: false
+
+cache:
+  directories:
+    - node_modules
+
+before_install:
+  - npm config set spin false
+  - npm install -g bower
+  - bower --version
+  - npm install phantomjs-prebuilt
+  - node_modules/phantomjs-prebuilt/bin/phantomjs --version
+
+install:
+  - npm install
+  - bower install
+
+script:
+  - npm test

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,53 @@
+# Share-analytics-dashboard
+
+This README outlines the details of collaborating on this Ember application.
+A short introduction of this app could easily go here.
+
+## Prerequisites
+
+You will need the following things properly installed on your computer.
+
+* [Git](http://git-scm.com/)
+* [Node.js](http://nodejs.org/) (with NPM)
+* [Bower](http://bower.io/)
+* [Ember CLI](http://ember-cli.com/)
+* [PhantomJS](http://phantomjs.org/)
+
+## Installation
+
+* `git clone <repository-url>` this repository
+* `cd share-analytics-dashboard`
+* `npm install`
+* `bower install`
+
+## Running / Development
+
+* `ember serve`
+* Visit your app at [http://localhost:4200](http://localhost:4200).
+
+### Code Generators
+
+Make use of the many generators for code, try `ember help generate` for more details
+
+### Running Tests
+
+* `ember test`
+* `ember test --server`
+
+### Building
+
+* `ember build` (development)
+* `ember build --environment production` (production)
+
+### Deploying
+
+Specify what it takes to deploy your app.
+
+## Further Reading / Useful Links
+
+* [ember.js](http://emberjs.com/)
+* [ember-cli](http://ember-cli.com/)
+* Development Browser Extensions
+  * [ember inspector for chrome](https://chrome.google.com/webstore/detail/ember-inspector/bmdblncegkenkacieihfhpjfppoconhi)
+  * [ember inspector for firefox](https://addons.mozilla.org/en-US/firefox/addon/ember-inspector/)
+

--- a/client/app/components/c3-chart/component.js
+++ b/client/app/components/c3-chart/component.js
@@ -47,7 +47,7 @@ export default Ember.Component.extend({
                 type: chart_type,
                 onclick: (d) => {
                     let queryParams = {
-                        'topic': d
+                        'id': d.id
                     };
                     this.attrs.transitionToFacet('topic', queryParams);
                 },

--- a/client/app/components/list-widget/component.js
+++ b/client/app/components/list-widget/component.js
@@ -22,7 +22,7 @@ export default Ember.Component.extend({
 
         transitionToFacet(parameter) {
             let queryParams = {
-                "id": parameter
+                "id": parameter.name
             };
             this.attrs.transitionToFacet(this.get('item.facetDash'), queryParams);
         }

--- a/client/app/components/list-widget/component.js
+++ b/client/app/components/list-widget/component.js
@@ -16,6 +16,17 @@ export default Ember.Component.extend({
                 name: item.key,
             };
         }));
+    },
+
+    actions: {
+
+        transitionToFacet(parameter) {
+            let queryParams = {
+                "id": parameter
+            };
+            this.attrs.transitionToFacet('topic', queryParams);
+        }
+
     }
 
 });

--- a/client/app/components/list-widget/component.js
+++ b/client/app/components/list-widget/component.js
@@ -24,7 +24,7 @@ export default Ember.Component.extend({
             let queryParams = {
                 "id": parameter
             };
-            this.attrs.transitionToFacet('topic', queryParams);
+            this.attrs.transitionToFacet(this.get('item.facetDash'), queryParams);
         }
 
     }

--- a/client/app/components/list-widget/template.hbs
+++ b/client/app/components/list-widget/template.hbs
@@ -3,7 +3,7 @@
         <a href="#" class="list-widget-item">
             <div class="row">
                 <div class="item-number col-xs-3">{{item.number}}</div>
-                <div class="item-name col-xs-7">{{item.name}}</div>
+                <div class="item-name col-xs-7"><button {{action "transitionToFacet" item}}>{{item.name}}</button></div>
                 <div class="item-name col-xs-2"><i class="fa fa-angle-right"></i></div>
             </div>
         </a>

--- a/client/app/components/widget-adapter/component.js
+++ b/client/app/components/widget-adapter/component.js
@@ -1,5 +1,5 @@
 import Ember from 'ember';
-import ENV from 'tc3/config/environment';
+import ENV from 'analytics-dashboard/config/environment';
 
 //import Q from 'npm:q';
 const agg_types = [ // agg_types is this array literal, reduced by the following fn

--- a/client/app/components/widget-adapter/component.js
+++ b/client/app/components/widget-adapter/component.js
@@ -536,7 +536,6 @@ export default Ember.Component.extend({
                 Ember.run.schedule('afterRender', self, function() {
                     let controller = route.get('controller');
                     controller.set('query', queryParams);
-                    debugger;
                     controller.set('id', queryParams.id);
                     controller.set('back', 'backroute');
                 });

--- a/client/app/components/widget-adapter/component.js
+++ b/client/app/components/widget-adapter/component.js
@@ -534,9 +534,10 @@ export default Ember.Component.extend({
             let self = this;
             this.get('router').transitionTo('dashboards.dashboard', dashboardName).then(function(route) {
                 Ember.run.schedule('afterRender', self, function() {
-                    debugger;
                     let controller = route.get('controller');
                     controller.set('query', queryParams);
+                    debugger;
+                    controller.set('id', queryParams.id);
                     controller.set('back', 'backroute');
                 });
             });

--- a/client/app/controllers/dashboards/dashboard.js
+++ b/client/app/controllers/dashboards/dashboard.js
@@ -2,8 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
 
-    queryParams: ['id'],
-    id: '',
+    queryParams: ['id', 'query', 'q', 'institutionName', 'tag', 'topic'],
 
     wall: false,
     

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>Tc3</title>
+    <title>SHARE :: Analytics</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {{content-for "head"}}
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
-    <link rel="stylesheet" href="{{rootURL}}assets/tc3.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/analytics-dashboard.css">
 
     {{content-for "head-footer"}}
   </head>
@@ -18,7 +18,7 @@
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>
-    <script src="{{rootURL}}assets/tc3.js"></script>
+    <script src="{{rootURL}}assets/analytics-dashboard.js"></script>
 
     {{content-for "body-footer"}}
   </body>

--- a/client/app/routes/dashboards/dashboard.js
+++ b/client/app/routes/dashboards/dashboard.js
@@ -132,6 +132,7 @@ export default Ember.Route.extend({
                                 parameterName: "id"
                             }
                         ],
+                        facetDash: "worktype"
                     },
                     {
                         chartType: 'topContributors',
@@ -162,6 +163,7 @@ export default Ember.Route.extend({
                                 parameterPath: ["query", "bool", "must", "query_string", "query"]
                             }
                         ],
+                        facetDash: "scholar"
                     },
                     {
                         chartType: 'donut',
@@ -220,6 +222,7 @@ export default Ember.Route.extend({
                                 parameterPath: ["query", "bool", "must", 0, "query_string", "query"]
                             }
                         ],
+                        facetDash: "funder"
                     }
                 ]
             },
@@ -311,13 +314,15 @@ export default Ember.Route.extend({
                         widgetSettings : {
                             fontSize: 2,
                             fontColor: '#F44336'
-                        }
+                        },
+                        facedtDash: "scholar"
                     },
                     {
                         chartType: 'timeseries',
                         widgetType: 'c3-chart',
                         name:'Date Histogram',
                         width: 12,
+                        facetDash: "arttype",
                         post_body: {
                             "query": {
                                 "bool": {
@@ -366,7 +371,7 @@ export default Ember.Route.extend({
                                 parameterPath: ["query", "bool", "filter", "term", "sources.raw"],
                                 parameterName: "institutionName"
                             }
-                        ],
+                        ]
                     },
                     {
                         chartType: 'topContributors',
@@ -397,6 +402,7 @@ export default Ember.Route.extend({
                                 parameterPath: ["query", "bool", "must", "query_string", "query"]
                             }
                         ],
+                        facetDash: "scholar"
                     },
                     {
                         chartType: 'donut',
@@ -445,6 +451,7 @@ export default Ember.Route.extend({
                                 parameterPath: ["query", "bool", "must", 0, "query_string", "query"]
                             }
                         ],
+                        facetDash: "funder"
                     },
                     {
                         chartType: 'topContributors',
@@ -475,6 +482,7 @@ export default Ember.Route.extend({
                                 parameterPath: ["query", "bool", "must", "query_string", "query"]
                             }
                         ],
+                        facetDash: "topic"
                     }
                 ]
             },
@@ -585,6 +593,7 @@ export default Ember.Route.extend({
                                 parameterPath: ["query", "bool", "must", 0, "query_string", "query"]
                             }
                         ],
+                        facetDash: "arttype"
                     },
                     {
                         chartType: 'topContributors',
@@ -617,6 +626,7 @@ export default Ember.Route.extend({
                                 parameterPath: ["query", "bool", "must", "query_string", "query"]
                             }
                         ],
+                        facetDash: "scholar"
                     },
                     {
                         chartType: 'donut',
@@ -649,6 +659,7 @@ export default Ember.Route.extend({
                         },
                         postBodyParams: [
                         ],
+                        facetDash: "institution",
                     },
                     {
                         chartType: 'topContributors',
@@ -679,6 +690,7 @@ export default Ember.Route.extend({
                                 parameterPath: ["query", "bool", "must", "query_string", "query"]
                             }
                         ],
+                        facetDash: "scholar"
                     },
                     {
                         chartType: 'relevanceHistogram',
@@ -735,6 +747,7 @@ export default Ember.Route.extend({
                                 }
                             }
                         },
+                        facetDash: "shareresults",
                         postBodyParams: [
                             {
                                 parameterName: "query",

--- a/client/app/routes/dashboards/dashboard.js
+++ b/client/app/routes/dashboards/dashboard.js
@@ -37,44 +37,54 @@ export default Ember.Route.extend({
                         name: 'Total Results',
                         width: 4,
                         post_body: {
-                            query: {
-                                bool: {
-                                  must: {
-                                    query_string: {query: query}
-                                  }
+                            "query": {
+                                "bool": {
+                                    "filter": {
+                                        "term": {
+                                            "contributors.raw": null
+                                        }
+                                    }
                                 }
                             }
                         },
                         postBodyParams: [
                             {
-                                parameterName: "query",
-                                parameterPath: ["query", "bool", "must", "query_string", "query"]
+                                parameterName: "id",
+                                parameterPath: ["query", "bool", "filter", "term", "contributors.raw"]
                             }
                         ],
                     },
                     {
                         chartType: 'totalPublications',
                         widgetType: 'number-widget',
-                        name: 'Total Publications',
+                        name: 'Total Papers',
                         width: 4,
                         post_body: {
-                            query: {
-                                bool: {
-                                    must: {
-                                        query_string: {query: query}
-                                    },
-                                    filter: [{
-                                        term: {
-                                            'type.raw': "publication"
+                            "query": {
+                                "filtered": {
+                                    "filter": {
+                                        "bool": {
+                                            "must": [
+                                                {
+                                                    "term": {
+                                                        'type': "paper"
+                                                    }
+                                                },
+                                                {
+                                                    "term": {
+                                                        "contributors.raw": null
+                                                    }
+                                                }
+                                            ]
                                         }
-                                    }]
+                                    }
                                 }
                             }
                         },
                         postBodyParams: [
                             {
-                                parameterName: "query",
-                                parameterPath: ["query", "bool", "must", "query_string", "query"]
+                                parameterName: "id",
+                                parameterPath: ["query", "filtered", "filter", "bool", "must", 1, "term", "contributors.raw"]
                             }
                         ],
                     },

--- a/client/app/routes/dashboards/dashboard.js
+++ b/client/app/routes/dashboards/dashboard.js
@@ -325,7 +325,7 @@ export default Ember.Route.extend({
                             fontSize: 2,
                             fontColor: '#F44336'
                         },
-                        facedtDash: "scholar"
+                        facetDash: "scholar"
                     },
                     {
                         chartType: 'timeseries',
@@ -516,7 +516,7 @@ export default Ember.Route.extend({
                         },
                         postBodyParams: [
                             {
-                                parameterName: "query",
+                                parameterName: "id",
                                 parameterPath: ["query", "bool", "must", "query_string", "query"]
                             }
                         ],
@@ -542,7 +542,7 @@ export default Ember.Route.extend({
                         },
                         postBodyParams: [
                             {
-                                parameterName: "query",
+                                parameterName: "id",
                                 parameterPath: ["query", "bool", "must", "query_string", "query"]
                             }
                         ],
@@ -599,7 +599,7 @@ export default Ember.Route.extend({
                         },
                         postBodyParams: [
                             {
-                                parameterName: "query",
+                                parameterName: "id",
                                 parameterPath: ["query", "bool", "must", 0, "query_string", "query"]
                             }
                         ],
@@ -632,7 +632,7 @@ export default Ember.Route.extend({
                         },
                         postBodyParams: [
                             {
-                                parameterName: "query",
+                                parameterName: "id",
                                 parameterPath: ["query", "bool", "must", "query_string", "query"]
                             }
                         ],
@@ -696,7 +696,7 @@ export default Ember.Route.extend({
                         },
                         postBodyParams: [
                             {
-                                parameterName: "query",
+                                parameterName: "id",
                                 parameterPath: ["query", "bool", "must", "query_string", "query"]
                             }
                         ],
@@ -760,7 +760,7 @@ export default Ember.Route.extend({
                         facetDash: "shareresults",
                         postBodyParams: [
                             {
-                                parameterName: "query",
+                                parameterName: "id",
                                 parameterPath: ["query", "bool", "must", 0, "query_string", "query"]
                             }
                         ],
@@ -785,7 +785,9 @@ export default Ember.Route.extend({
 
     setupController: function(controller, model) {
         this._super(controller, model);
-        controller.set('query', model.query);
+        if (controller.get('query') === undefined) {
+            controller.set('query', model.query);
+        }
         controller.set('institutionName', "eScholarship @ University of California");
         controller.set('widgets', model.widgets.map((widget) => {
             if (widget.postBodyParams) {

--- a/client/app/templates/dashboards/dashboard.hbs
+++ b/client/app/templates/dashboards/dashboard.hbs
@@ -1,7 +1,7 @@
 <div class='container-fluid'>
     <div class='row'>
         <div class='col-md-12'>
-            <h2>Dashboard</h2>
+            <h2>{{item.dashboardName}}</h2>
         </div>
     </div>
 </div>

--- a/client/config/environment.js
+++ b/client/config/environment.js
@@ -3,7 +3,7 @@
 module.exports = function(environment) {
     var ENV = {
         authorizationType: 'token',
-        modulePrefix: 'tc3',
+        modulePrefix: 'analytics-dashboard',
         environment: environment,
         rootURL: '/',
         locationType: 'auto',

--- a/client/package.json
+++ b/client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tc3",
+  "name": "analytics-dashboard",
   "version": "0.0.0",
   "description": "Small description for tc3 goes here",
   "private": true,


### PR DESCRIPTION
Adds a transitionToFacet function in the widget-adapter component. Requires widget components to call it with two parameters, a name of a dashboard to transition to, and an object that provides query parameters to set once transitioned.

Adds a facetDash property to widget model; allows to transition to the named dashboard, the facet's name or id location is specified by the widget component.

Name of the project is changed from Tc3 to analytics-dashboard