### PR TITLE
Fix Institution "top contributors" and "top tags" queries

### DIFF
--- a/client/app/routes/dashboards/dashboard.js
+++ b/client/app/routes/dashboards/dashboard.js
@@ -283,7 +283,7 @@ export default Ember.Route.extend({
             },
             institution: {
                 dasboardName: 'Institution Overview Dashboard',
-                query: 'UC San Diego',
+                query: '*',
                 widgets: [
                     {
                         chartType: 'totalResults',
@@ -438,7 +438,12 @@ export default Ember.Route.extend({
                                 bool: {
                                     must: {
                                         query_string: {query: query}
-                                    }
+                                    },
+                                   "filter": [{
+                                        "term": {
+                                            "sources.raw": "eScholarship @ University of California"
+                                        }
+                                   }]
                                 }
                             },
                             from: 0,
@@ -868,7 +873,7 @@ export default Ember.Route.extend({
                                 }
                             }
                         },
-                        facetDash: "shareresults"                        
+                        facetDash: "shareresults"
                     },
                 ]
             }

--- a/client/app/routes/dashboards/dashboard.js
+++ b/client/app/routes/dashboards/dashboard.js
@@ -523,7 +523,12 @@ export default Ember.Route.extend({
                                 bool: {
                                     must: {
                                         query_string: {query: query}
-                                    }
+                                    },
+                                    filter: [{
+                                        term: {
+                                            "sources.raw": "eScholarship @ University of California"
+                                        }
+                                   }]
                                 }
                             },
                             from: 0,


### PR DESCRIPTION
On the institution dashboard, filter by source instead of putting the name of the institution in the
query for top contributors and top tags.