### PR TITLE
Fix info/institution_id route

### DIFF
--- a/client/app/routes/info.js
+++ b/client/app/routes/info.js
@@ -1,7 +1,17 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
-  renderTemplate() {
-    this.render('ucsd-about');
+  model(params) {
+    // TODO: Replace with model loaded from store
+    return {
+      'id': 'ucsd',
+      'name': 'UC San Diego',
+      'description': 'Data from the UC San Diego research community in the SHARE catalog.',
+      'dashboards': []
+    };
+  },
+  renderTemplate(controller, model) {
+    var template = model.id + '-about';
+    this.render(template);
   }
 });

--- a/client/app/routes/info.js
+++ b/client/app/routes/info.js
@@ -1,4 +1,7 @@
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  renderTemplate() {
+    this.render('ucsd-about');
+  }
 });

--- a/client/app/templates/info.hbs
+++ b/client/app/templates/info.hbs
@@ -1,18 +1,1 @@
-<div class="widget">
-  <div class="widget-body">
-    <h5><b>What is this?</b></h5>
-    <p>The Research Data Catalog pulls information about data created by members of the UC San Diego research community from the SHARE database.</p>
-
-    <h5><b>Where does the data come from?</b></h5>
-    <p>SHARE is a higher education initiative whose mission is to maximize research impact by making a comprehensive inventory of research widely discoverable, accessible, and reusable. To fulfill this mission SHARE is creating an openly available data set about research activities across their life cycle.</p>
-    <p>The SHARE infrastructure was developed by the Association of Research Libraries in partnership with the Center for Open Science. SHARE is funded by the Institute of Museum and Library Services and the Alfred P. Sloan Foundation. The SHARE initiative was founded in 2013 by ARL, the Association of American Universities (AAU), and the Association of Public and Land-grant Universities (APLU).</p>
-    <p>The Research Data Catalog is a joint development effort between the SHARE team and the UC San Diego Library. The Library team includes members of the Research Data Curation, Metadata Services and Information Technology Programs.</p>
-
-    <h5>How do I get my data listed?</h5>
-    <p>SHARE harvests from {X number of} sources from around the world. Publishing data in any of these services will have it harvested. NOTE HOWEVER that for your data to be represented in the Research Data Catalog, it must be clearly identified as coming from UC San Diego. How this is done will vary by source. For help, please contact the UC San Diego Library.</p>
-    <p>In addition to these sources, the UC San Diego Library can manually enter information into the SHARE catalog. Contact them to begin the process. The Library also hosts data data via its Data Collections website, which also publishes to the SHARE catalog. Contact them for more information.</p>
-
-    <h5>I see an error in the representation of my data! How do I correct it?</h5>
-    <p>Because SHARE harvests from more than X number of international services, there will be different answers to this question. Contact the UC San Diego Library for help.</p>
-  </div>
-</div>
+{{outlet}}

--- a/client/app/templates/ucsd-about.hbs
+++ b/client/app/templates/ucsd-about.hbs
@@ -1,0 +1,18 @@
+<div class="widget">
+  <div class="widget-body">
+    <h5><b>What is this?</b></h5>
+    <p>The Research Data Catalog pulls information about data created by members of the UC San Diego research community from the SHARE database.</p>
+
+    <h5><b>Where does the data come from?</b></h5>
+    <p>SHARE is a higher education initiative whose mission is to maximize research impact by making a comprehensive inventory of research widely discoverable, accessible, and reusable. To fulfill this mission SHARE is creating an openly available data set about research activities across their life cycle.</p>
+    <p>The SHARE infrastructure was developed by the Association of Research Libraries in partnership with the Center for Open Science. SHARE is funded by the Institute of Museum and Library Services and the Alfred P. Sloan Foundation. The SHARE initiative was founded in 2013 by ARL, the Association of American Universities (AAU), and the Association of Public and Land-grant Universities (APLU).</p>
+    <p>The Research Data Catalog is a joint development effort between the SHARE team and the UC San Diego Library. The Library team includes members of the Research Data Curation, Metadata Services and Information Technology Programs.</p>
+
+    <h5>How do I get my data listed?</h5>
+    <p>SHARE harvests from {X number of} sources from around the world. Publishing data in any of these services will have it harvested. NOTE HOWEVER that for your data to be represented in the Research Data Catalog, it must be clearly identified as coming from UC San Diego. How this is done will vary by source. For help, please contact the UC San Diego Library.</p>
+    <p>In addition to these sources, the UC San Diego Library can manually enter information into the SHARE catalog. Contact them to begin the process. The Library also hosts data data via its Data Collections website, which also publishes to the SHARE catalog. Contact them for more information.</p>
+
+    <h5>I see an error in the representation of my data! How do I correct it?</h5>
+    <p>Because SHARE harvests from more than X number of international services, there will be different answers to this question. Contact the UC San Diego Library for help.</p>
+  </div>
+</div>


### PR DESCRIPTION
- Create separate template for the ucsd about page 
- Dynamically render an about page template based on the `institution_id` route param

Note: If the template does not exist, the page will not load.