### PR TITLE
Remove "About" and "Search" widget headings

### DIFF
--- a/client/app/routes/dashboards/dashboard.js
+++ b/client/app/routes/dashboards/dashboard.js
@@ -381,17 +381,17 @@ export default Ember.Route.extend({
                     {
                         widgetType: "query-widget",
                         background_color: "000000",
-                        name: "Search",
+                        name: "",
                         width: 8,
                         facetDashParameter: "query",
-                        facetDash: "resultsList",
+                        facetDash: "resultsList"
                     },
                     {
                         chartType: 'totalResults',
                         widgetType: 'number-widget',
                         name: 'Total Results',
                         width: 4,
-                        height: 144,
+                        height: 115,
                         post_body: {},
                         postBodyParams: [
                             {

--- a/client/app/routes/dashboards/dashboard.js
+++ b/client/app/routes/dashboards/dashboard.js
@@ -372,7 +372,7 @@ export default Ember.Route.extend({
                 widgets: [
                     {
                         widgetType: "about-text-widget",
-                        name: "About",
+                        name: "",
                         width: 12,
                         widgetSettings : {
                             institution_id: 'ucsd'

--- a/client/app/styles/app.css
+++ b/client/app/styles/app.css
@@ -1,3 +1,5 @@
+@import "components/about-text-widget.css";
+
 /*Packery grid styling*/
 
 .ucsd_header {

--- a/client/app/styles/components/about-text-widget.css
+++ b/client/app/styles/components/about-text-widget.css
@@ -1,0 +1,3 @@
+.about-text-widget {
+    min-height: 50px!important;
+}


### PR DESCRIPTION
Remove "About" and "Search" widget headings:

![screen shot 2017-01-26 at 3 53 48 pm](https://cloud.githubusercontent.com/assets/6414394/22351151/a0f43dfe-e3e4-11e6-9b2e-2c197e2eea4d.png)
