### PR TITLE
Keep table numbers on the same line

### DIFF
--- a/client/app/styles/app.css
+++ b/client/app/styles/app.css
@@ -399,6 +399,7 @@ nav.navbar {
 .list-widget .item-number {
     font-size: 18px;
     color: #F44336;
+    word-break: normal;
 }
 .list-widget .item-name {
     font-size: 16px;


### PR DESCRIPTION
Prevent numbers in the list-widget from wrapping onto a second line by adding `word-break:normal` to the `.list-widget .item-number` css class.