### PR TITLE
Fix data providers chart for curated UCSD data

### DIFF
--- a/client/app/components/c3-chart/component.js
+++ b/client/app/components/c3-chart/component.js
@@ -148,6 +148,19 @@ export default Ember.Component.extend({
 
             var _data = this.get('data');
 
+            if (this.get('data').length === 0 && this.get('name') === 'Data Providers') {
+                var key = 'UC San Diego Library';
+                var data = [{
+                   'key': key,
+                   'doc_count': 55,
+                   '_source': {
+                      'id': key,
+                      'name': key
+                   }
+                }];
+                this.set('data', data);
+            }
+
             if (this.get('item.mappingType') === 'OBJECT_TO_ARRAY') {
                 var columns = this.get('data').map(({ key, doc_count }) => [key, doc_count]);
             }


### PR DESCRIPTION
Hard-code UCSD as the publisher for the records on this page, since they do not include publisher info:  

![screen shot 2017-02-01 at 3 40 50 pm](https://cloud.githubusercontent.com/assets/6414394/22525365/dfceead8-e894-11e6-961a-0bd0a9efd5f3.png)
