### PR TITLE
Fix app title link not working with ‘source’ query paremeter

### DIFF
--- a/client/app/controllers/application.js
+++ b/client/app/controllers/application.js
@@ -17,10 +17,7 @@ export default Ember.Controller.extend(OsfAgnosticAuthControllerMixin,{
             this.get('toast').error('Login failed');
         },
         transitionToHome(){
-            debugger;
-            this.transitionToRoute('dashboards.dashboard', 'institution', {
-                queryParams: {all : 'ucsd'}
-            });
+            this.transitionToRoute('dashboards.dashboard', 'institution');
         }
     }
 });


### PR DESCRIPTION
Saman found this error where "when I click on the title, it redirects to http://localhost:4200/dashboards/institution?all=ucsd&source=UC%20San%20Diego%20Library instead of either the all or source page". This was because all=ucsd was being added to the route for all instances. 

This change removes the queryparameters option when changing routes. 