### PR TITLE
Remove unnecessary view all links

### DIFF
--- a/client/app/routes/dashboards/dashboard.js
+++ b/client/app/routes/dashboards/dashboard.js
@@ -854,6 +854,7 @@ export default Ember.Route.extend({
                         name: 'Recently Added',
                         facetDash: "objectDetail",
                         facetDashParameter: "id",
+                        hideViewAll: true,
                         width: 12,
                         post_body : {
                           "sort": { "date": { "order": "desc" }}
@@ -870,7 +871,7 @@ export default Ember.Route.extend({
                             },
                             {
                                 parameterName: "source",
-                                parameterPath: ["query", "bool", "filter", 0, "term", "sources.raw"],
+                                parameterPath: ["query", "bool", "filter", 0, "term", "sources.raw"]
                             },
                             {
                                 parameterName: "recently_added_sort",
@@ -882,7 +883,7 @@ export default Ember.Route.extend({
                                 parameterPath: ["query", "bool", "must", 0, "query_string", "query"],
                                 defaultValue: "*"
                             }
-                        ],
+                        ]
                     }
                 ]
             },
@@ -1738,6 +1739,7 @@ export default Ember.Route.extend({
                         facetDash: "objectDetail",
                         facetDashParameter: "id",
                         width: 12,
+                        hideViewAll: true,
                         post_body : {
                           "sort": { "date": { "order": "desc" }}
                         },

--- a/client/app/routes/dashboards/dashboard.js
+++ b/client/app/routes/dashboards/dashboard.js
@@ -1223,6 +1223,7 @@ export default Ember.Route.extend({
                         facetDash: "agentDetail",
                         dataType: 'contributors',
                         facetDashParameter: "id",
+                        hideViewAll: true,
                         post_body : {
                             "aggregations": {
                                 "listWidgetData": {
@@ -1237,7 +1238,7 @@ export default Ember.Route.extend({
                             {
                                 parameterPath: ["aggregations", "contributors", "terms", "field"],
                                 parameterName: "contributors_id_field",
-                                defaultValue: "lists.contributors.id.raw",
+                                defaultValue: "lists.contributors.id.raw"
                             },
                             {
                                 parameterPath: ["query", "bool", "minimum_should_match"],
@@ -1255,9 +1256,9 @@ export default Ember.Route.extend({
                             },
                             {
                                 parameterName: "source",
-                                parameterPath: ["query", "bool", "filter", 0, "term", "sources.raw"],
+                                parameterPath: ["query", "bool", "filter", 0, "term", "sources.raw"]
                             }
-                        ],
+                        ]
                     }
                 ]
             },


### PR DESCRIPTION
Hide view all link in: 
- The recently added widget (currently the link doesn't go anywhere)
- The contributors index widget (already displays more contributors so a view all link is not needed)