### PR TITLE
Use v3 share index for data providers chart

### DIFF
--- a/client/app/routes/dashboards/dashboard.js
+++ b/client/app/routes/dashboards/dashboard.js
@@ -1503,7 +1503,7 @@ export default Ember.Route.extend({
                         chartType: 'donut',
                         widgetType: 'c3-chart',
                         name: 'Data Providers',
-                        indexVersion: "2",
+                        indexVersion: "3",
                         width: 6,
                         mappingType: "OBJECT_TO_ARRAY",
                         facetDash: "agentDetail",


### PR DESCRIPTION
On the institution2 dashboard, make the data providers chart use the v3 SHARE index to fix the eternal spinner.