### PR TITLE
Fix links for tags on the tags dashboard

### DIFF
--- a/client/app/routes/dashboards/dashboard.js
+++ b/client/app/routes/dashboards/dashboard.js
@@ -1412,7 +1412,7 @@ export default Ember.Route.extend({
                 wrapperClass: 'index-page',
                 widgets: [
                     {
-                        chartType: 'topContributors',
+                        chartType: 'tagsList',
                         widgetType: 'list-widget',
                         name: 'Top Tags',
                         width: 12,
@@ -1460,8 +1460,9 @@ export default Ember.Route.extend({
                                 parameterPath: ["query", "bool", "filter", 2, "term", "contributors.exact"],
                             }
                         ],
-                        facetDash: "scholar"
-                    },
+                        facetDash: "resultsList",
+                        facetDashParameter: "tags"
+                    }
                 ]
             },
             providers: {


### PR DESCRIPTION
Just like the tags link to the search results dashboard in the top tags widget, the tags in the "View more" tags page should also link to the search results.