### PR TITLE
Fix Data Providers View all link

### DIFF
--- a/client/app/components/c3-chart/component.js
+++ b/client/app/components/c3-chart/component.js
@@ -404,6 +404,10 @@ export default Ember.Component.extend({
             if(override){
                 facetDash = override;
             }
+            if (id === null) {
+                this.attrs.transitionToFacet(facetDash, queryParams);
+                return;
+            }
             if (facetDash === "url" && item.url) {
                 window.location.href = item.url;
                 return;

--- a/client/app/routes/dashboards/dashboard.js
+++ b/client/app/routes/dashboards/dashboard.js
@@ -1507,7 +1507,6 @@ export default Ember.Route.extend({
                         widgetType: 'contributors-widget',
                         name: 'Data providers',
                         width: 12,
-                        indexVersion: "2",
                         facetDash: "agentDetail",
                         facetDashParameter: "id",
                         hideViewAll: true,


### PR DESCRIPTION
The data providers widget View All link was going through the same transition logic as the individual donut slices, when it is supposed to transition to the providers dashboard. If the passed in id is null, transition to the facetDash.