### PR TITLE
Fix number-widget height

### DIFF
--- a/client/app/components/widget-adapter/template.hbs
+++ b/client/app/components/widget-adapter/template.hbs
@@ -1,4 +1,4 @@
-<div class='widget {{widgetType}}' style="height: {{height}}px">
+<div class='widget {{widgetType}}' style="height: {{height}}px; min-height: {{item.widgetSettings.minHeight}}px;">
     <div class='widgetButtons'>
         <h4>{{item.name}}</h4>
     </div>

--- a/client/app/routes/dashboards/dashboard.js
+++ b/client/app/routes/dashboards/dashboard.js
@@ -579,7 +579,6 @@ export default Ember.Route.extend({
                         width: 3,
                         indexVersion: 3,
                         facetDash: "resultsList",
-                        height: 115,
                         post_body: {},
                         postBodyParams: [
                             {
@@ -615,7 +614,8 @@ export default Ember.Route.extend({
                         ],
                         widgetSettings : {
                             fontSize: 2,
-                            fontColor: '#F44336'
+                            fontColor: '#F44336',
+                            minHeight: 115
                         }
                     },
                     {
@@ -794,7 +794,6 @@ export default Ember.Route.extend({
                         name: 'Total Results',
                         width: 4,
                         facetDash: "resultsList",
-                        height: 115,
                         post_body: {},
                         postBodyParams: [
                             {
@@ -818,7 +817,8 @@ export default Ember.Route.extend({
                         ],
                         widgetSettings : {
                             fontSize: 2,
-                            fontColor: '#F44336'
+                            fontColor: '#F44336',
+                            minHeight: 115
                         }
                     },
                     {
@@ -1675,7 +1675,6 @@ export default Ember.Route.extend({
                         name: 'Total Results',
                         width: 4,
                         facetDash: "resultsList",
-                        height: 115,
                         post_body: {},
                         postBodyParams: [
                             {
@@ -1699,7 +1698,8 @@ export default Ember.Route.extend({
                         ],
                         widgetSettings : {
                             fontSize: 2,
-                            fontColor: '#F44336'
+                            fontColor: '#F44336',
+                            minHeight: 115
                         }
                     },
                     {


### PR DESCRIPTION
Set the min-height to match the height of the search widget so that the height adjusts when large numbers wrap onto a second line.