### PR TITLE
Link types in type chart to resultsList dashboard

### DIFF
--- a/client/app/components/stacked-bars/component.js
+++ b/client/app/components/stacked-bars/component.js
@@ -41,8 +41,7 @@ export default Ember.Component.extend({
                 number: item.doc_count,
                 label: item.key,
                 percentage: percentage,
-                background: this.get('pattern')[index] || '#666666',
-                url: "https://share.osf.io/discover?" + query + "&type=" + item.key
+                background: this.get('pattern')[index] || '#666666'
             };
         });
         this.set('data', data);
@@ -105,15 +104,24 @@ export default Ember.Component.extend({
         component.$('.stack').click(function(event){
             let index = component.$(event.target).attr('data-index');
             let item = component.get('data')[index];
-            if (item.url) {
-                window.location.href = item.url;
-                return;
-            }
+            component.send('transitionToFacet', item);
         })
     },
     init() {
         this._super(...arguments);
         this.setData();
+    },
+    actions: {
+        transitionToFacet(item) {
+              let queryParams = {};
+              var facet = this.get("item.facetDashParameter");
+              if (facet) {
+                  queryParams[facet] = item.label;
+                  this.attrs.transitionToFacet(this.get('item.facetDash'), queryParams);
+              } else if (item.url) {
+                window.location.href = item.url;
+              }
+          }
     }
 
 });

--- a/client/app/controllers/dashboards/dashboard.js
+++ b/client/app/controllers/dashboards/dashboard.js
@@ -11,7 +11,8 @@ export default Ember.Controller.extend({
         {'tag': {scope: "controller"}},
         {'tags': {scope: "controller"}},
         {'topic': {scope: "controller"}},
-        {'publishers': {scope: "controller"}}
+        {'publishers': {scope: "controller"}},
+        {'type': {scope: "controller"}}
     ],
 
     updateParams: Ember.observer('queryParams', function() {

--- a/client/app/routes/dashboards/dashboard.js
+++ b/client/app/routes/dashboards/dashboard.js
@@ -191,6 +191,7 @@ export default Ember.Route.extend({
         contributors: {refreshModel: true},
         special_filter: {refreshModel: true},
         publishers: {refreshModel: true},
+        type: {refreshModel: true}
     },
     query: 'UC',
     gte: "1996-01-01",
@@ -221,6 +222,7 @@ export default Ember.Route.extend({
             controller.set("publishers", undefined);
             controller.set("tags", undefined);
             controller.set("query", undefined);
+            controller.set("type", undefined);
         }
     },
     model: function(params, transition, queryParams) {
@@ -583,6 +585,10 @@ export default Ember.Route.extend({
                             {
                                 parameterName: "contributors",
                                 parameterPath: ["query", "bool", "filter", 3, "term", "lists.contributors.id.exact"],
+                            },
+                            {
+                                parameterName: "type",
+                                parameterPath: ["query", "bool", "filter", 4, "term", "type"]
                             }
                         ]
                     },
@@ -624,6 +630,10 @@ export default Ember.Route.extend({
                             {
                                 parameterName: "contributors",
                                 parameterPath: ["query", "bool", "filter", 3, "term", "lists.contributors.id.exact"],
+                            },
+                            {
+                                parameterName: "type",
+                                parameterPath: ["query", "bool", "filter", 4, "term", "type"]
                             }
                         ],
                         widgetSettings : {
@@ -693,6 +703,10 @@ export default Ember.Route.extend({
                                 parameterPath: ["query", "bool", "filter", 3, "term", "lists.contributors.id.exact"],
                             },
                             {
+                                parameterName: "type",
+                                parameterPath: ["query", "bool", "filter", 4, "term", "type"]
+                            },
+                            {
                                 parameterPath: ["aggregations", "publishers", "terms", "field"],
                                 parameterName: "publisher_field",
                                 defaultValue: "lists.publishers.id.exact",
@@ -750,6 +764,10 @@ export default Ember.Route.extend({
                             {
                                 parameterName: "contributors",
                                 parameterPath: ["query", "bool", "filter", 3, "term", "lists.contributors.id.exact"],
+                            },
+                            {
+                                parameterName: "type",
+                                parameterPath: ["query", "bool", "filter", 4, "term", "type"]
                             }
                         ],
                     },
@@ -907,6 +925,8 @@ export default Ember.Route.extend({
                         widgetType: "stacked-bars",
                         name: "Types",
                         width: 12,
+                        facetDash: "resultsList",
+                        facetDashParameter: "type",
                         post_body: {},
                         postBodyParams: [
                             {


### PR DESCRIPTION
In the stacked-bar chart displaying the breakdown of results by type, clicking on a type should take the user to the results dashboard (instead of the OSF share page), showing the corresponding results.