### PR TITLE
Fix transitionToViewAll in list-widget

### DIFF
--- a/app/components/list-widget/component.js
+++ b/app/components/list-widget/component.js
@@ -188,7 +188,7 @@ export default Ember.Component.extend({
             }
         },
         transitionToViewAll(item) {
-            this.attrs.transitionToFacet(item.dataType, item);
+            this.attrs.transitionToFacet(item.dataType, {});
         }
     }
 });

--- a/app/components/list-widget/template.hbs
+++ b/app/components/list-widget/template.hbs
@@ -1,8 +1,8 @@
 <table style="width: 100%;"class="list-widget widget-body">
-    {{#each data as |item|}}
+    {{#each data as |listItem|}}
         <tr href="#" class="list-widget-item">
-                <td class="item-number" {{action "transitionToFacet" item}}>{{item.number}}</td>
-                <td class="item-name" {{action "transitionToFacet" item}}>{{item.name}}</td>
+                <td class="item-number" {{action "transitionToFacet" listItem}}>{{listItem.number}}</td>
+                <td class="item-name" {{action "transitionToFacet" listItem}}>{{listItem.name}}</td>
         </tr>
     {{/each}}
 </table>


### PR DESCRIPTION
The`item` (the widget definition) was getting passed to the `transitionToFacet` action as the new query params and then set as the `parameters` property on the dashboard route. Since tags are built from `parameters`, this caused extra tags to show up:  
![screen shot 2017-03-27 at 1 51 21 pm](https://cloud.githubusercontent.com/assets/6414394/24377565/c8351f20-130d-11e7-8cef-1091e5f27bfe.png)

Replace `item` with `{}` since there are no new query params that need to get set when transitioning to the view all route.
