### PR TITLE
Make contributors on object detail page link to results page

### DIFF
--- a/app/components/object-detail-widget/template.hbs
+++ b/app/components/object-detail-widget/template.hbs
@@ -8,7 +8,7 @@
     {{/if}}
     <div><h3>Contributors</h3><ul>
         {{#each objectData._source.lists.contributors as |contributor|}}
-            <li><a style="cursor: pointer;" {{action "transitionToFacet" "agentDetail" "id" contributor.id}}>{{contributor.name}}</a></li>
+            <li><a style="cursor: pointer;" {{action "transitionToFacet" "resultsList" "contributors" contributor.id}}>{{contributor.name}}</a></li>
         {{/each}}
     </ul></div>
     {{#if objectData._source.tags}}


### PR DESCRIPTION
Make contributor names listed on an "object detail" page link to the search results page faceted by that user.