### PR TITLE
Fix search page UI when no results are found [SIDASH-51]

### DIFF
--- a/app/components/c3-chart/template.hbs
+++ b/app/components/c3-chart/template.hbs
@@ -1,10 +1,14 @@
 <div class="widget-body clearfix">
     <div class="renderChart"></div>
-    {{#if widgetSettings.viewAllRoute}}
-        {{#unless item.hideViewAll}}
-            <div class="text-right m-t-md">
-                <button class="btn btn-link text-bigger" {{action 'transitionToFacet' null 'providers'}}>View all</button>
-            </div>
-        {{/unless}}
+    {{#if data.length}}
+        {{#if widgetSettings.viewAllRoute}}
+            {{#unless item.hideViewAll}}
+                <div class="text-right m-t-md">
+                    <button class="btn btn-link text-bigger" {{action 'transitionToFacet' null 'providers'}}>View all</button>
+                </div>
+            {{/unless}}
+        {{/if}}
+    {{else}}
+        <p class="text-center">No data providers</p>
     {{/if}}
 </div>

--- a/app/components/contributors-widget/template.hbs
+++ b/app/components/contributors-widget/template.hbs
@@ -1,17 +1,23 @@
 <table style="width: 100%;"class="list-widget widget-body">
-    {{#each data as |datum|}}
-        <tr href="#" class="list-widget-item">
-                    <td class="item-number">{{datum.number}}</td>
-                    <td class="item-name">
-                        <a {{ action "transitionToFacet" datum.id }}>
-                            {{datum.name}}
-                        </a>
-                    </td>
-        </tr>
-    {{/each}}
+    {{#if data.length}}
+        {{#each data as |datum|}}
+            <tr href="#" class="list-widget-item">
+                <td class="item-number">{{datum.number}}</td>
+                <td class="item-name">
+                    <a {{ action "transitionToFacet" datum.id }}>
+                        {{datum.name}}
+                    </a>
+                </td>
+            </tr>
+        {{/each}}
+    {{else}}
+        <tr class="text-center">No contributors</tr>
+    {{/if}}
 </table>
-{{#unless item.hideViewAll}}
-    <div class="text-right m-t-md">
-        <button class="btn btn-link text-bigger" {{action 'transitionToViewAll' item}}>View more</button>
-    </div>
-{{/unless}}
+{{#if data.length}}
+    {{#unless item.hideViewAll}}
+        <div class="text-right m-t-md">
+            <button class="btn btn-link text-bigger" {{action 'transitionToViewAll' item}}>View more</button>
+        </div>
+    {{/unless}}
+{{/if}}

--- a/app/components/contributors-widget/template.hbs
+++ b/app/components/contributors-widget/template.hbs
@@ -10,8 +10,6 @@
                 </td>
             </tr>
         {{/each}}
-    {{else}}
-        <tr class="text-center">No contributors</tr>
     {{/if}}
 </table>
 {{#if data.length}}
@@ -20,4 +18,6 @@
             <button class="btn btn-link text-bigger" {{action 'transitionToViewAll' item}}>View more</button>
         </div>
     {{/unless}}
+{{else}}
+    <p class="text-center">No contributors</p>
 {{/if}}

--- a/app/components/number-widget/component.js
+++ b/app/components/number-widget/component.js
@@ -2,14 +2,13 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
 
-    total: 'hello',
+    total: null,
 
     settings : {
         fontSize: 3,
         fontColor: '#F44336',
         pre:'',
-        post: '',
-        value: 0
+        post: ''
     },
 
     init () {
@@ -22,10 +21,7 @@ export default Ember.Component.extend({
 
     didReceiveAttrs() {
         this._super(...arguments);
-        var unformatted = this.total
-        if (!unformatted) {
-            unformatted = this.settings.value
-        }
+        var unformatted = this.total || 0;
         this.set('total', unformatted.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ","));
     },
 

--- a/app/components/results-list/template.hbs
+++ b/app/components/results-list/template.hbs
@@ -30,7 +30,7 @@
             </div>
         </div>
     {{else}}
-        <h3 class="text-center p-b-lg">
+        <h3 class="text-center p-t-md">
             No results found.
         </h3>
     {{/each}}

--- a/app/components/results-list/template.hbs
+++ b/app/components/results-list/template.hbs
@@ -29,14 +29,15 @@
                 </div>
             </div>
         </div>
-        {{else}}
+    {{else}}
         <h3 style="text-align: center;">
             No results found.
         </h3>
     {{/each}}
-    <div style="text-align: center; padding: 30px;">
-        <button class="btn btn-primary" {{action "pageback"}}>{{fa-icon "chevron-left"}}</button>
-        <button class="btn btn-primary" {{action "pagenext"}}>{{fa-icon "chevron-right"}}</button>
-    </div>  
-
+    {{#if data}}
+        <div style="text-align: center; padding: 30px;">
+            <button class="btn btn-primary" {{action "pageback"}}>{{fa-icon "chevron-left"}}</button>
+            <button class="btn btn-primary" {{action "pagenext"}}>{{fa-icon "chevron-right"}}</button>
+        </div>
+    {{/if}}
 </div>

--- a/app/components/results-list/template.hbs
+++ b/app/components/results-list/template.hbs
@@ -30,7 +30,7 @@
             </div>
         </div>
     {{else}}
-        <h3 style="text-align: center;">
+        <h3 class="results-text">
             No results found.
         </h3>
     {{/each}}

--- a/app/components/results-list/template.hbs
+++ b/app/components/results-list/template.hbs
@@ -34,7 +34,7 @@
             No results found.
         </h3>
     {{/each}}
-    {{#if data}}
+    {{#if data.length}}
         <div style="text-align: center; padding: 30px;">
             <button class="btn btn-primary" {{action "pageback"}}>{{fa-icon "chevron-left"}}</button>
             <button class="btn btn-primary" {{action "pagenext"}}>{{fa-icon "chevron-right"}}</button>

--- a/app/components/results-list/template.hbs
+++ b/app/components/results-list/template.hbs
@@ -30,7 +30,7 @@
             </div>
         </div>
     {{else}}
-        <h3 class="results-text">
+        <h3 class="text-center p-b-lg">
             No results found.
         </h3>
     {{/each}}

--- a/app/routes/dashboards/dashboard.js
+++ b/app/routes/dashboards/dashboard.js
@@ -601,7 +601,10 @@ export default Ember.Route.extend({
                                 parameterName: "page",
                                 parameterPath: ["from"]
                             }
-                        ]
+                        ],
+                        widgetSettings : {
+                            minHeight: 115
+                        }
                     },
                     {
                         chartType: 'totalResults',

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -433,6 +433,10 @@ nav.navbar {
     -webkit-animation: spinner .6s linear infinite;
 }
 
+.c3-chart {
+  padding-bottom:20px;
+}
+
 .contributors-widget {
     padding-bottom: 20px;
 }

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,4 +1,3 @@
-@import "components/about-text-widget.css";
 @import "components/results-list.css";
 
 /*Packery grid styling*/

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,4 +1,5 @@
 @import "components/about-text-widget.css";
+@import "components/results-list.css";
 
 /*Packery grid styling*/
 

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1,5 +1,3 @@
-@import "components/results-list.css";
-
 /*Packery grid styling*/
 
 body {

--- a/app/styles/components/about-text-widget.css
+++ b/app/styles/components/about-text-widget.css
@@ -1,3 +1,0 @@
-.about-text-widget {
-    min-height: 50px!important;
-}

--- a/app/styles/components/results-list.css
+++ b/app/styles/components/results-list.css
@@ -1,0 +1,4 @@
+.results-text {
+  text-align: center;
+  padding-bottom: 20px;
+}

--- a/app/styles/components/results-list.css
+++ b/app/styles/components/results-list.css
@@ -1,4 +1,0 @@
-.results-text {
-  text-align: center;
-  padding-bottom: 20px;
-}


### PR DESCRIPTION
Fix how the search results page looks when no results are found: 
- Hide pagination arrows
- Make "Total Results" widget display 0 results
- Make contributors list widget say "No contributors" and hide "View more" link
- Make data providers widget say "No data providers" and hide "View all" link

![screen shot 2017-03-31 at 3 14 57 pm](https://cloud.githubusercontent.com/assets/6414394/24566143/53df5a66-1626-11e7-9aee-31103c158f8c.png)
