### PR TITLE
Remove overflow that blocks the visibility of tooltips on stacked bars [SIDASH-58]

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -602,7 +602,6 @@ nav.navbar {
     padding-top:15px;
     padding-bottom: 1px;
     color: #ffffff;
-    overflow: hidden;
     text-align: center;
     cursor: pointer;
     margin-bottom: 10px;


### PR DESCRIPTION
There was an "overflow: hidden" rule on the stacks. I looked into the history but couldn’t find why this was necessary. Overflow is not harming view as far as I can tell. It must have been added because of a bug related to too much text but I can’t replicate it even with long type names. 