### PR TITLE
Object detail page updates [SIDASH-77][SIDASH-78][SIDASH-79][SIDASH-67]

### DIFF
--- a/app/components/object-detail-widget/component.js
+++ b/app/components/object-detail-widget/component.js
@@ -31,6 +31,19 @@ export default Ember.Component.extend({
         return httpUrl;
     }),
 
+    funders: Ember.computed('objectData._source.lists.funders', function() {
+        var data = this.get('objectData');
+        var funders = data._source.lists.funders;
+        return funders.map((funder) => {
+            var total = 0;
+            for (var award of funder.awards) {
+                total += award.amount;
+            }
+            var formattedTotal = total.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+            return {name: funder.name, awardTotal: formattedTotal}
+        })
+    }),
+
     init(){
         this._super(...arguments);
         let data = this.processData(this.get('data'));

--- a/app/components/object-detail-widget/component.js
+++ b/app/components/object-detail-widget/component.js
@@ -32,14 +32,9 @@ export default Ember.Component.extend({
     }),
 
     funders: Ember.computed('objectData._source.lists.funders', function() {
-        var data = this.get('objectData');
-        var funders = data._source.lists.funders;
-        return funders.map((funder) => {
-            var total = 0;
-            for (var award of funder.awards) {
-                total += award.amount;
-            }
-            var formattedTotal = total.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+        this.get('objectData')._source.lists.funders.map((funder) => {
+            let total = funder.awards.reduce((total, award) => total + award.amount)
+            let formattedTotal = total.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
             return {name: funder.name, awardTotal: formattedTotal}
         })
     }),

--- a/app/components/object-detail-widget/template.hbs
+++ b/app/components/object-detail-widget/template.hbs
@@ -30,12 +30,15 @@
             </ul>
         </div>
     {{/if}}
-    <div>Date: {{objectData._source.date}}</div>
-    <div>Date Created: {{objectData._source.date_created}}</div>
-    <div>Date Modified: {{objectData._source.date_modified}}</div>
-    <div>Date Published: {{objectData._source.date_published}}</div>
-    <div>Date Updated: {{objectData._source.date_updated}}</div>
-    <div>Language: {{objectData._source.language}}</div>
+
+    {{#if objectData._source.language}}
+        <div>
+            <h3>Language</h3>
+            <ul>
+                <li>{{objectData._source.language}}</li>
+            </ul>
+        </div>
+    {{/if}}
 
     {{#if objectData._source.identifiers}}
         <div>
@@ -61,6 +64,17 @@
             </ul>
         </div>
     {{/if}}
+
+    <div>
+        <h3>Dates</h3>
+        <ul>
+            <li>Date: {{objectData._source.date}}</li>
+            <li>Date Created: {{objectData._source.date_created}}</li>
+            <li>Date Modified: {{objectData._source.date_modified}}</li>
+            <li>Date Published: {{objectData._source.date_published}}</li>
+            <li>Date Updated: {{objectData._source.date_updated}}</li>
+        </ul>
+    </div>
 
     {{#if showJSON}}
         <h4 {{action toggleProperty 'showJSON'}} style="font-weight: 600; margin-top: 50px; cursor: pointer;">Hide Raw Data&nbsp;&nbsp;&nbsp;&nbsp;{{fa-icon "chevron-up"}}</h4>

--- a/app/components/object-detail-widget/template.hbs
+++ b/app/components/object-detail-widget/template.hbs
@@ -5,21 +5,10 @@
         <a class="btn btn-md" href="{{dataUrl}}" style="display: inline-block; background-color: #bbb; color: #fff; padding: 10px 30px; font-size: 17px; border-radius: 2px; font-weight: 600; margin-top: 30px;">Access Data</a>
         {{/if}}
     </h1>
-    {{#if objectData._source.description}}
-        <div><h3>Description</h3>{{objectData._source.description}}</div>
-    {{/if}}
-    <div><h3>Contributors</h3><ul>
-        {{#each objectData._source.lists.contributors as |contributor|}}
-            <li><a style="cursor: pointer;" {{action "transitionToFacet" "search" "contributors" contributor.id}}>{{contributor.name}}</a></li>
-        {{/each}}
-    </ul></div>
-    {{#if objectData._source.tags}}
-        <div><h3>Tags</h3>
-            {{#each objectData._source.tags as |tag|}}
-                <span {{action "transitionToFacet" "search" "tags" tag true on="click"}} style="cursor: pointer; display: inline-block; font-size: 12px; background-color: #7ec4dd; color: #fff; padding: 2px 5px 2px 5px ; border: 1px solid color: #6ebfd5; border-radius: 3px; margin: 3px;">{{tag}}</span>
-            {{/each}}
-        </div>
-    {{/if}}
+
+    <h3>Resource Type</h3>
+    <ul><li>{{objectData._source.type}}</li></ul>
+
     {{#if objectData._source.publishers}}
         <div>
             <h3>Data Providers</h3>
@@ -28,6 +17,49 @@
                     <li>{{publisher}}</li>
                 {{/each}}
             </ul>
+        </div>
+    {{/if}}
+
+    {{#if objectData._source.description}}
+        <div><h3>Description</h3>{{objectData._source.description}}</div>
+    {{/if}}
+
+    <div>
+        <h3>Contributors</h3>
+        <ul>
+            {{#each objectData._source.lists.contributors as |contributor|}}
+                <li><a style="cursor: pointer;" {{action "transitionToFacet" "search" "contributors" contributor.id}}>{{contributor.name}}</a></li>
+            {{/each}}
+        </ul>
+    </div>
+
+    {{#if objectData._source.affiliations}}
+        <div>
+            <h3>Affiliations</h3>
+            <ul>
+                {{#each objectData._source.affiliations as |affiliation|}}
+                  <li>{{affiliation}}</li>
+                {{/each}}
+            </ul>
+        </div>
+    {{/if}}
+
+    {{#if objectData._source.funders}}
+        <div>
+            <h3>Funders</h3>
+            <ul>
+                {{#each objectData._source.funders as |funder|}}
+                  <li>{{funder}}</li>
+                {{/each}}
+            </ul>
+        </div>
+    {{/if}}
+
+    {{#if objectData._source.tags}}
+        <div><h3>Tags</h3>
+            {{#each objectData._source.tags as |tag|}}
+                <span {{action "transitionToFacet" "search" "tags" tag true on="click"}} style="cursor: pointer; display: inline-block; font-size: 12px; background-color: #7ec4dd; color: #fff; padding: 2px 5px 2px 5px ; border: 1px solid color: #6ebfd5; border-radius: 3px; margin: 3px;">{{tag}}</span>
+            {{/each}}
         </div>
     {{/if}}
 
@@ -50,9 +82,6 @@
             </ul>
         </div>
     {{/if}}
-
-    <h3>Source Type</h3>
-    <ul><li>{{objectData._source.type}}</li></ul>
 
     {{#if objectData._source.sources}}
         <div>

--- a/app/components/object-detail-widget/template.hbs
+++ b/app/components/object-detail-widget/template.hbs
@@ -44,12 +44,12 @@
         </div>
     {{/if}}
 
-    {{#if objectData._source.funders}}
+    {{#if funders}}
         <div>
             <h3>Funders</h3>
             <ul>
-                {{#each objectData._source.funders as |funder|}}
-                  <li>{{funder}}</li>
+                {{#each funders as |funder|}}
+                  <li>{{funder.name}}: ${{funder.awardTotal}}</li>
                 {{/each}}
             </ul>
         </div>


### PR DESCRIPTION
- Reorder metadata according to https://openscience.atlassian.net/browse/SIDASH-67
- Add funder and affiliation information 
- Add headers for dates and language section 

Note: 
- This PR does not add related works, since it is not available in the elasticsearch record. E.g https://share.osf.io/dataset/46177-54B-9AB is a record that has related works, but the dashboard page for that record does not: https://cos-labs.github.io/share-analytics/#/objectDetail?id=46177-54B-9AB. 