### PR TITLE
Remove language field on objectDetail page [SIDASH-67]

### DIFF
--- a/app/components/object-detail-widget/template.hbs
+++ b/app/components/object-detail-widget/template.hbs
@@ -63,15 +63,6 @@
         </div>
     {{/if}}
 
-    {{#if objectData._source.language}}
-        <div>
-            <h3>Language</h3>
-            <ul>
-                <li>{{objectData._source.language}}</li>
-            </ul>
-        </div>
-    {{/if}}
-
     {{#if identifierURLs}}
         <div>
             <h3>Identifiers</h3>


### PR DESCRIPTION
Removes the language field on the object detail page as per discussion here: https://openscience.atlassian.net/browse/SIDASH-67