### PR TITLE
Replace tag ids with display name [SIDASH-52]

### DIFF
--- a/app/components/filter-plaques/component.js
+++ b/app/components/filter-plaques/component.js
@@ -20,7 +20,7 @@ export default Ember.Component.extend({
       var ids = filters.filter((item) => {
           return ID_FILTERS.indexOf(item.key) !== -1;
       }).map((param) => {
-          return {key: param.value, doc_count: 0}
+          return {key: param.value}
       });
 
       // Fetch display names

--- a/app/components/filter-plaques/component.js
+++ b/app/components/filter-plaques/component.js
@@ -24,7 +24,7 @@ export default Ember.Component.extend({
       });
 
       // Fetch display names
-      if (ids.length !== 0) {
+      if (ids.length > 0) {
         this.fetchAgentDetails(ids).then((data) => {
           if (filters) {
             var displayFilters = filters.map((filter) => {

--- a/app/components/filter-plaques/component.js
+++ b/app/components/filter-plaques/component.js
@@ -26,7 +26,6 @@ export default Ember.Component.extend({
       // Fetch display names
       if (ids.length > 0) {
         this.fetchAgentDetails(ids).then((data) => {
-          if (filters) {
             var displayFilters = filters.map((filter) => {
               var value = filter.value;
               data.forEach((agentData) => {
@@ -37,7 +36,6 @@ export default Ember.Component.extend({
               return {key: filter.key, value: value};
             });
             this.set('filters', displayFilters);
-          }
         });
       }},
 

--- a/app/components/filter-plaques/component.js
+++ b/app/components/filter-plaques/component.js
@@ -26,17 +26,20 @@ export default Ember.Component.extend({
       // Fetch display names
       if (ids.length !== 0) {
         this.fetchAgentDetails(ids).then((data) => {
-          for (var i = 0; i < data.length; i++) {
-            for (var filter = 0; filter < filters.length; filter++) {
-              if (filters[filter].value === data[i].id) {
-                  Ember.set(filters[filter], 'value', data[i].name);
-              }
-            }
+          if (filters) {
+            var displayFilters = filters.map((filter) => {
+              var value = filter.value;
+              data.forEach((agentData) => {
+                if (value === agentData.id) {
+                  value = agentData.name;
+                }
+              });
+              return {key: filter.key, value: value};
+            });
+            this.set('filters', displayFilters);
           }
         });
-      }
-      this.set('filters', filters);
-    },
+      }},
 
     fetchAgentDetails: async function(data) {
         let agent_details = await Ember.$.ajax({

--- a/app/components/filter-plaques/component.js
+++ b/app/components/filter-plaques/component.js
@@ -7,13 +7,13 @@ export default Ember.Component.extend({
     init () {
       this._super(...arguments);
       let parameters = this.get('parameters');
-      var filters = Object.keys(parameters).map((key) => {
+      var filters = Object.keys(parameters).filter((key) => {
+        return key !== "page";
+      }).map((key) => {
         return {
           "key": key,
           "value": parameters[key]
         }
-      }).filter((item) => {
-        return item.key !== "page";
       });
 
       // Find and format all query params that use ids for the value

--- a/app/components/filter-plaques/component.js
+++ b/app/components/filter-plaques/component.js
@@ -38,11 +38,11 @@ export default Ember.Component.extend({
       this.set('filters', filters);
     },
 
-    fetchAgentDetails: async function(data) {
+    fetchAgentDetails: async function(agentList) {
         let agent_details = await Ember.$.ajax({
             url: 'https://dev-labs.cos.io/bulk_get_agents',
             crossDomain: true,
-            data: JSON.stringify(data),
+            data: JSON.stringify(agentList),
             type: 'POST',
             contentType: 'application/json'
         });

--- a/app/components/filter-plaques/component.js
+++ b/app/components/filter-plaques/component.js
@@ -26,18 +26,20 @@ export default Ember.Component.extend({
       // Fetch display names
       if (ids.length > 0) {
         this.fetchAgentDetails(ids).then((data) => {
-            var displayFilters = filters.map((filter) => {
-              var value = filter.value;
-              data.forEach((agentData) => {
-                if (value === agentData.id) {
-                  value = agentData.name;
-                }
-              });
-              return {key: filter.key, value: value};
-            });
-            this.set('filters', displayFilters);
+          var displayFilters = filters.map((filter) => {
+            var value = filter.value;
+            for (let agentData of data) {
+              if (value === agentData.id) {
+                value = agentData.name;
+                break;
+              }
+            }
+            return {key: filter.key, value: value};
+          });
+          this.set('filters', displayFilters);
         });
-      }},
+      }
+    },
 
     fetchAgentDetails: async function(agentList) {
         let agent_details = await Ember.$.ajax({

--- a/app/components/filter-plaques/component.js
+++ b/app/components/filter-plaques/component.js
@@ -1,21 +1,52 @@
 import Ember from 'ember';
 
-export default Ember.Component.extend({
+var ID_FILTERS = ['contributors', 'funders', 'publishers'];
 
+export default Ember.Component.extend({
+    filters: null,
     init () {
-        this._super(...arguments);
-        let parameters = this.get('parameters');
-        this.set('filters', Object.keys(parameters).map((key, idx, arr) => {
-            return {
-                "key": key,
-                "value": parameters[key]
+      this._super(...arguments);
+      let parameters = this.get('parameters');
+      var filters = Object.keys(parameters).map((key) => {
+        return {
+          "key": key,
+          "value": parameters[key]
+        }
+      }).filter((item) => {
+        return item.key !== "page";
+      });
+
+      // Find and format all query params that use ids for the value
+      var ids = filters.filter((item) => {
+          return ID_FILTERS.indexOf(item.key) !== -1;
+      }).map((param) => {
+          return {key: param.value, doc_count: 0}
+      });
+
+      // Fetch display names
+      if (ids.length !== 0) {
+        this.fetchAgentDetails(ids).then((data) => {
+          for (var i = 0; i < data.length; i++) {
+            for (var filter = 0; filter < filters.length; filter++) {
+              if (filters[filter].value === data[i].id) {
+                  Ember.set(filters[filter], 'value', data[i].name);
+              }
             }
-        }).filter((item) => {
-            if (item.key == "page") {
-                return false;
-            }
-            return true;
-        }));
+          }
+        });
+      }
+      this.set('filters', filters);
+    },
+
+    fetchAgentDetails: async function(data) {
+        let agent_details = await Ember.$.ajax({
+            url: 'https://dev-labs.cos.io/bulk_get_agents',
+            crossDomain: true,
+            data: JSON.stringify(data),
+            type: 'POST',
+            contentType: 'application/json'
+        });
+        return JSON.parse(agent_details);
     },
 
     actions: {


### PR DESCRIPTION
Fixes: https://openscience.atlassian.net/browse/SIDASH-52

The ids for contributors, funders and publishers are used to filter the search results page. However,
the tag that gets displayed should show the name of the contributor/funder/publisher instead of the id used for filtering.

Make a request to the api gateway bulk_agents endpoint that makes a bulk request to SHARE to get record data. Then replace the tag ids with their correct display names.