### PR TITLE
Use id for funder query parameter but display name [SIDASH-84]

### DIFF
--- a/app/components/dropdown-widget/component.js
+++ b/app/components/dropdown-widget/component.js
@@ -57,8 +57,14 @@ export default Ember.Component.extend({
     processData (data) {
         data.forEach(item => {
             if(item.doc_count > 0){
-                this.get('dropList').addObject(item.key);
-                this.get('filteredList').addObject(item.key);
+                let obj = {
+                  key: item.key
+                };
+                if(item.name){
+                  obj.name = item.name.buckets[0].key;
+                }
+                this.get('dropList').addObject(obj);
+                this.get('filteredList').addObject(obj);
             }
         });
     },

--- a/app/components/dropdown-widget/template.hbs
+++ b/app/components/dropdown-widget/template.hbs
@@ -11,7 +11,7 @@
                 <option value="" selected=selected>Select Type</option>
             {{/unless}}
             {{#each dropList as |type|}}
-                <option value={{type}} selected={{if (eq selectedType type) true}}>{{type}}</option>
+                <option value={{type.key}} selected={{if (eq selectedType type.key) true}}>{{type.key}}</option>
             {{/each}}
         </select>
     </div>
@@ -28,8 +28,12 @@
       {{#if showList}}
           <div class="dropdown-search">
               {{#each filteredList as |item|}}
-                  <div class="dropdown-search-item" {{action "applySelection" item}}>
-                      {{item}}
+                  <div class="dropdown-search-item" {{action "applySelection" item.key}}>
+                      {{#if item.name}}
+                        {{item.name}}
+                      {{else}}
+                        {{item.key}}
+                      {{/if}}
                   </div>
               {{/each}}
           </div>

--- a/app/routes/dashboards/dashboard.js
+++ b/app/routes/dashboards/dashboard.js
@@ -693,8 +693,15 @@ export default Ember.Route.extend({
                             "aggregations": {
                                 "dropdownList" : {
                                     "terms": {
-                                        "field": 'funders.exact',
+                                        "field": "lists.funders.id.exact",
                                         "size": 100
+                                    },
+                                    "aggs" : {
+                                        "name": {
+                                            "terms": {
+                                                "field": "lists.funders.name.exact"
+                                            }
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
## Purpose
The newly implemented funders were faceting with funder name but the query parameter needs funder id. This PR fixes that while still showing funder name in search list. 
 