### PR TITLE
Remove link from number widget [SIDASH-59]

### DIFF
--- a/app/components/number-widget/template.hbs
+++ b/app/components/number-widget/template.hbs
@@ -1,3 +1,3 @@
 <div class="widget-body clearfix">
-    <div class="widget-number size-{{settings.fontSize}} is-link" style="color:{{settings.fontColor}};"><span {{action "transitionToFacet"}}>{{settings.pre}}{{total}}{{settings.post}}</span></div>
+    <div class="widget-number size-{{settings.fontSize}}" style="color:{{settings.fontColor}};"><span>{{settings.pre}}{{total}}{{settings.post}}</span></div>
 </div>


### PR DESCRIPTION
## Purpose
Removes .is-link from the number widget and associated action. 
