### PR TITLE
Add spinner to all widgets [SIDASH-86]

### DIFF
--- a/app/components/widget-adapter/component.js
+++ b/app/components/widget-adapter/component.js
@@ -350,6 +350,12 @@ export default Ember.Component.extend({
 
     aggregations: false,
     docs: false,
+    loadingData: Ember.computed('data', function(){
+        if(this.get('data')){
+          return false;
+        }
+        return true;
+    }),
 
     classNameBindings: ['configuring', 'picking', 'width', 'height'],
 

--- a/app/components/widget-adapter/component.js
+++ b/app/components/widget-adapter/component.js
@@ -351,10 +351,7 @@ export default Ember.Component.extend({
     aggregations: false,
     docs: false,
     loadingData: Ember.computed('data', function(){
-        if(this.get('data')){
-          return false;
-        }
-        return true;
+        return !this.get('data');
     }),
 
     classNameBindings: ['configuring', 'picking', 'width', 'height'],

--- a/app/components/widget-adapter/template.hbs
+++ b/app/components/widget-adapter/template.hbs
@@ -52,5 +52,8 @@
 
     {{component widgetType parameters=parameters data=data widgetSettings=item.widgetSettings chartType=chartType aggregations=aggregations name=item.name item=item width=widthSetting height=heightSetting interval=tsInterval resizedSignal=resizedSignal total=total transitionToFacet=(action 'transitionToFacet')}}
 
+    {{#if loadingData}}
+       <div class="ball-pulse ball-dark text-center p-lg"><div></div><div></div><div></div></div>
+    {{/if}}
     {{yield}}
 </div>

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -637,6 +637,11 @@ nav.navbar {
     width: 25px;
 }
 
+/* override osf-style ball-dark spinner color */
+.ball-dark > div {
+  background-color: #dbe2ef;
+}
+
 /**
  * Tooltip Styles from : https://chrisbracco.com/a-simple-css-tooltip/
 


### PR DESCRIPTION
## Purpose
When widget data is taking time to load there is no indicator to show what is happening. This PR adds ball-pulse spinners with a lighter color. See below for when all loading indicators are visible. 

<img width="996" alt="screen shot 2017-05-10 at 10 44 58 am" src="https://cloud.githubusercontent.com/assets/1314003/25904729/11863c5e-356e-11e7-9c81-1985f85baba3.png">
