### PR TITLE
Add text and round currency for awards widget [SIDASH-75]

### DIFF
--- a/app/components/c3-chart/component.js
+++ b/app/components/c3-chart/component.js
@@ -168,7 +168,6 @@ export default Ember.Component.extend({
                         var percentage = Math.floor(percent*100);
                         if (self.get('name') === 'Awards') {
                             let roundedValue = currencyRounder(value);
-                            console.log(roundedValue);
                             return percentage + "% ($" + roundedValue + ")";
 
                         }

--- a/app/components/c3-chart/component.js
+++ b/app/components/c3-chart/component.js
@@ -1,6 +1,7 @@
 /* global c3 */
 import Ember from 'ember';
 import ENV from 'analytics-dashboard/config/environment';
+import currencyRounder from '../../utils/currency-rounder';
 
 
 const NIH_LABELS = {
@@ -166,8 +167,10 @@ export default Ember.Component.extend({
                     value: function (value, percent, id) {
                         var percentage = Math.floor(percent*100);
                         if (self.get('name') === 'Awards') {
-                            var formatted = value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-                            return percentage + "% ($" + formatted + ")";
+                            let roundedValue = currencyRounder(value);
+                            console.log(roundedValue);
+                            return percentage + "% ($" + roundedValue + ")";
+
                         }
                         return percentage + "% (" + value + " records)"; // This isn't perfect, but it's at least more verbose than before
                     }

--- a/app/components/c3-chart/template.hbs
+++ b/app/components/c3-chart/template.hbs
@@ -1,4 +1,10 @@
 <div class="widget-body clearfix">
+  {{#if widgetSettings.helpText}}
+    <div class="text-muted text-smaller">
+      <i>({{widgetSettings.helpText}})</i>
+    </div>
+  {{/if}}
+
     <div class="renderChart"></div>
     {{#if data.length}}
         {{#if widgetSettings.viewAllRoute}}

--- a/app/routes/dashboards/dashboard.js
+++ b/app/routes/dashboards/dashboard.js
@@ -1347,7 +1347,10 @@ export default Ember.Route.extend({
                                     parameterName: "date_range_format",
                                     defaultValue: "yyyy-MM-dd||yyyy"
                                 }
-                            ]
+                            ],
+                            widgetSettings: {
+                              helpText: 'Click on a section to view associated records'
+                            }
                         }
                 ]
             },
@@ -1527,7 +1530,10 @@ export default Ember.Route.extend({
                                     parameterName: "date_range_format",
                                     defaultValue: "yyyy-MM-dd||yyyy"
                                 }
-                            ]
+                            ],
+                            widgetSettings: {
+                              helpText: 'Click on a section to view associated records'
+                            }
                         },
                     {
                         widgetType: "stacked-bars",

--- a/app/routes/dashboards/dashboard.js
+++ b/app/routes/dashboards/dashboard.js
@@ -1037,7 +1037,10 @@ export default Ember.Route.extend({
                                     parameterName: "date_range_format",
                                     defaultValue: "yyyy-MM-dd||yyyy"
                                 }
-                            ]
+                            ],
+                            widgetSettings: {
+                              helpText: 'Click on a section to view associated records'
+                            }
                         },
                     {
                         chartType: 'tagsList',

--- a/app/utils/currency-rounder.js
+++ b/app/utils/currency-rounder.js
@@ -1,0 +1,22 @@
+/*
+  Returns letters with currencies to shorten them.
+  Taken from: http://stackoverflow.com/questions/36734201/how-to-convert-numbers-to-million-in-javascript
+ */
+export default function currencyRounder(rawValue) {
+
+  // Nine Zeroes for Billions
+  return Math.abs(Number(rawValue)) >= 1.0e+9
+
+    ? Math.round(Math.abs(Number(rawValue)) / 1.0e+9) + "B"
+    // Six Zeroes for Millions
+    : Math.abs(Number(rawValue)) >= 1.0e+6
+
+      ? Math.round(Math.abs(Number(rawValue)) / 1.0e+6) + "M"
+      // Three Zeroes for Thousands
+      : Math.abs(Number(rawValue)) >= 1.0e+3
+
+        ? Math.round(Math.abs(Number(rawValue)) / 1.0e+3) + "K"
+
+        // Otherwise return the number
+        : Math.abs(Number(rawValue));
+}

--- a/app/utils/currency-rounder.js
+++ b/app/utils/currency-rounder.js
@@ -3,20 +3,14 @@
   Taken from: http://stackoverflow.com/questions/36734201/how-to-convert-numbers-to-million-in-javascript
  */
 export default function currencyRounder(rawValue) {
-
-  // Nine Zeroes for Billions
-  return Math.abs(Number(rawValue)) >= 1.0e+9
-
-    ? Math.round(Math.abs(Number(rawValue)) / 1.0e+9) + "B"
-    // Six Zeroes for Millions
-    : Math.abs(Number(rawValue)) >= 1.0e+6
-
-      ? Math.round(Math.abs(Number(rawValue)) / 1.0e+6) + "M"
-      // Three Zeroes for Thousands
-      : Math.abs(Number(rawValue)) >= 1.0e+3
-
-        ? Math.round(Math.abs(Number(rawValue)) / 1.0e+3) + "K"
-
-        // Otherwise return the number
-        : Math.abs(Number(rawValue));
+    if (Math.abs(Number(rawValue)) >= 1.0e+9) {
+        return Math.round(Math.abs(Number(rawValue)) / 1.0e+9) + "B";
+    }
+    if (Math.abs(Number(rawValue)) >= 1.0e+6){
+        return Math.round(Math.abs(Number(rawValue)) / 1.0e+6) + "M";
+    }
+    if (Math.abs(Number(rawValue)) >= 1.0e+3) {
+        return Math.round(Math.abs(Number(rawValue)) / 1.0e+3) + "K";
+    }
+    return Math.abs(Number(rawValue));
 }

--- a/tests/index.html
+++ b/tests/index.html
@@ -11,6 +11,7 @@
     {{content-for "test-head"}}
 
     <link rel="stylesheet" href="{{rootURL}}assets/vendor.css">
+    <link rel="stylesheet" href="{{rootURL}}assets/analytics-dashboard.css">
     <link rel="stylesheet" href="{{rootURL}}assets/tc3.css">
     <link rel="stylesheet" href="{{rootURL}}assets/test-support.css">
 
@@ -23,6 +24,7 @@
 
     <script src="{{rootURL}}testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
+    <script src="{{rootURL}}assets/analytics-dashboard.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>
     <script src="{{rootURL}}assets/tc3.js"></script>
     <script src="{{rootURL}}assets/tests.js"></script>

--- a/tests/unit/utils/currency-rounder-test.js
+++ b/tests/unit/utils/currency-rounder-test.js
@@ -1,0 +1,10 @@
+import currencyRounder from 'analytics-dashboard/utils/currency-rounder';
+import { module, test } from 'qunit';
+
+
+// Replace this with your real tests.
+test('works with billions', function(assert) {
+  let rawValue = 180000000123;
+  let result = currencyRounder(rawValue);
+  assert.equal(result, '180B');
+});


### PR DESCRIPTION
## Purpose
This PR adds a helptext to chart widget type and utility to round currency.

## Changes
- Add widgetSettings.helpText field for chart widgets
- Add a helptext for awards widget "Click on a section to view associated records"
- Add a utiliity function to round currency to nearest Billion, Million or Thousand with output like 123M for 123000000. 
- Use utility for awards chart widget 