### PR TITLE
Replace Mathjax cdn [SIDASH-88]

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -17,7 +17,7 @@
   <body>
     {{content-for "body"}}
 
-    <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/analytics-dashboard.js"></script>
 


### PR DESCRIPTION
## Purpose
Replaces mathjax cdn to avoid load errors in js. More information from MAthjax announcement: https://www.mathjax.org/cdn-shutting-down/