### PR TITLE
Fix zero funding display in item detail [sidash 98]

### DIFF
--- a/app/components/object-detail-widget/component.js
+++ b/app/components/object-detail-widget/component.js
@@ -44,14 +44,15 @@ export default Ember.Component.extend({
 
     funders: Ember.computed('objectData._source.lists.funders', function() {
         var funders = this.get('objectData')._source.lists.funders;
+        let currency = '$';
         if (funders) {
             return funders.map((funder) => {
                 let total = funder.awards.reduce((total, award) => {
                     return total + award.amount;
                 }, 0);
-                let formattedTotal = total.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-                return {name: funder.name, awardTotal: formattedTotal}
-            })
+                let formattedTotal = total > 0 ? total.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") : null;
+                return {name: funder.name, awardTotal: formattedTotal, currency: currency};
+            });
         }
     }),
 

--- a/app/components/object-detail-widget/template.hbs
+++ b/app/components/object-detail-widget/template.hbs
@@ -49,7 +49,11 @@
             <h3>Funders</h3>
             <ul>
                 {{#each funders as |funder|}}
-                  <li>{{funder.name}}: ${{funder.awardTotal}}</li>
+                  <li>{{funder.name}}
+                    {{#if funder.awardTotal}}
+                      : {{funder.currency}}{{funder.awardTotal}}
+                    {{/if}}
+                  </li>
                 {{/each}}
             </ul>
         </div>


### PR DESCRIPTION
## Purpose
This fix adjusts the code so that zero amounts do not display, however it doesn't check data source. Currently the reason some funders are showing $0 is because the awards array that is returned is empty. I'm not sure if this data return is correct. 

See example in screenshot: 
![screen shot 2017-06-07 at 2 16 21 pm](https://user-images.githubusercontent.com/1314003/26894284-f07ef738-4b8b-11e7-872f-cbb50637046b.png)

