### PR TITLE
Fix clearing pagination query param [SIDASH-147]

### DIFF
--- a/app/components/filter-plaques/component.js
+++ b/app/components/filter-plaques/component.js
@@ -57,6 +57,7 @@ export default Ember.Component.extend({
         removeFilter(filter) {
             let queryParams = {};
             queryParams[filter.key] = undefined;
+            queryParams['page'] = undefined;
             this.attrs.transitionToFacet("search", queryParams);
         },
 


### PR DESCRIPTION
When a user clears a search filter, also clear the page query parameter so that the updated search begins from the first page.